### PR TITLE
Improve error thrown

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ class QueryError extends Error {
 
   constructor(message) {
     super(message)
+    this.name = 'QueryError'
     this.framesToPop = 1
   }
 }

--- a/index.js
+++ b/index.js
@@ -2,13 +2,23 @@
 
 type Queryable = Document | DocumentFragment | Element
 
+class InvariantError extends Error {
+  framesToPop: number
+
+  constructor(message) {
+    super(message)
+    this.name = 'Invariant Violation'
+    this.framesToPop = 1
+  }
+}
+
 export function closest<T: Element>(element: Element, selectors: string, type: Class<T>): T {
   const klass = type || HTMLElement
   const el = element.closest(selectors)
   if (el instanceof klass) {
     return el
   }
-  throw new Error(`Element not found: <${klass.name}> ${selectors}`)
+  throw new InvariantError(`Element not found: <${klass.name}> ${selectors}`)
 }
 
 export function query<T: Element>(context: Queryable, selectors: string, type: Class<T>): T {
@@ -17,7 +27,7 @@ export function query<T: Element>(context: Queryable, selectors: string, type: C
   if (el instanceof klass) {
     return el
   }
-  throw new Error(`Element not found: <${klass.name}> ${selectors}`)
+  throw new InvariantError(`Element not found: <${klass.name}> ${selectors}`)
 }
 
 export function querySelectorAll<T: Element>(context: Queryable, selectors: string, type: Class<T>): Array<T> {
@@ -37,7 +47,7 @@ export function namedItem<T: HTMLElement>(form: HTMLFormElement, itemName: strin
   if (el instanceof klass) {
     return el
   }
-  throw new Error(`Element not found by name: <${klass.name}> ${itemName}`)
+  throw new InvariantError(`Element not found by name: <${klass.name}> ${itemName}`)
 }
 
 export function getAttribute(element: Element, attributeName: string): string {
@@ -45,5 +55,5 @@ export function getAttribute(element: Element, attributeName: string): string {
   if (attribute != null) {
     return attribute
   }
-  throw new Error(`Attribute not found on element: ${attributeName}`)
+  throw new InvariantError(`Attribute not found on element: ${attributeName}`)
 }

--- a/index.js
+++ b/index.js
@@ -2,12 +2,11 @@
 
 type Queryable = Document | DocumentFragment | Element
 
-class InvariantError extends Error {
+class QueryError extends Error {
   framesToPop: number
 
   constructor(message) {
     super(message)
-    this.name = 'Invariant Violation'
     this.framesToPop = 1
   }
 }
@@ -18,7 +17,7 @@ export function closest<T: Element>(element: Element, selectors: string, type: C
   if (el instanceof klass) {
     return el
   }
-  throw new InvariantError(`Element not found: <${klass.name}> ${selectors}`)
+  throw new QueryError(`Element not found: <${klass.name}> ${selectors}`)
 }
 
 export function query<T: Element>(context: Queryable, selectors: string, type: Class<T>): T {
@@ -27,7 +26,7 @@ export function query<T: Element>(context: Queryable, selectors: string, type: C
   if (el instanceof klass) {
     return el
   }
-  throw new InvariantError(`Element not found: <${klass.name}> ${selectors}`)
+  throw new QueryError(`Element not found: <${klass.name}> ${selectors}`)
 }
 
 export function querySelectorAll<T: Element>(context: Queryable, selectors: string, type: Class<T>): Array<T> {
@@ -47,7 +46,7 @@ export function namedItem<T: HTMLElement>(form: HTMLFormElement, itemName: strin
   if (el instanceof klass) {
     return el
   }
-  throw new InvariantError(`Element not found by name: <${klass.name}> ${itemName}`)
+  throw new QueryError(`Element not found by name: <${klass.name}> ${itemName}`)
 }
 
 export function getAttribute(element: Element, attributeName: string): string {
@@ -55,5 +54,5 @@ export function getAttribute(element: Element, attributeName: string): string {
   if (attribute != null) {
     return attribute
   }
-  throw new InvariantError(`Attribute not found on element: ${attributeName}`)
+  throw new QueryError(`Attribute not found on element: ${attributeName}`)
 }


### PR DESCRIPTION
Aligns error thrown closer to flow's `invariant` error.

https://github.com/zertosh/invariant/blob/fae1c859f3eec25025dc6019bf7f7fdb78a27307/browser.js#L41-L45

* Adds an `InvariantError` error class mostly to satisfy the undefined `framesToPop` property.
* Sets name to `'Invariant Violation'` to match `invariant`.
* Adds `framesToPop` property to indicate it's the callers fault.