### PR TITLE
Add a typescript definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,11 @@
+export type Queryable = Document | DocumentFragment | Element;
+
+export function closest<T extends Element = HTMLElement>(context: Queryable, selectors: string, klass?: any): T;
+
+export function query<T extends Element = HTMLElement>(context: Queryable, selectors: string, klass?: any): T;
+
+export function querySelectorAll<T extends Element = HTMLElement>(context: Queryable, selectors: string, klass?: any): Array<T>;
+
+export function namedItem<T extends HTMLFormElement = HTMLFormElement>(form: T, itemName: string, klass?: any): RadioNodeList | Element;
+
+export function getAttribute(element: Element, attributeName: string): string;

--- a/package.json
+++ b/package.json
@@ -5,14 +5,14 @@
   "repository": "github/query-selector",
   "main": "dist/index.umd.js",
   "module": "dist/index.esm.js",
-  "types": "index.d.ts",
+  "types": "dist/index.d.ts",
   "scripts": {
     "clean": "rm -rf dist",
     "lint": "eslint index.js test/ && flow check",
     "prebuild": "npm run clean && npm run lint && mkdir dist",
     "build-umd": "BABEL_ENV=umd babel index.js -o dist/index.umd.js && cp index.js.flow dist/index.umd.js.flow",
     "build-esm": "BABEL_ENV=esm babel index.js -o dist/index.esm.js && cp index.js.flow dist/index.esm.js.flow",
-    "build": "npm run build-umd && npm run build-esm",
+    "build": "npm run build-umd && npm run build-esm && cp index.d.ts dist/index.d.ts",
     "test": "BABEL_ENV=umd mocha --require @babel/register",
     "prepublishOnly": "npm run build"
   },
@@ -22,8 +22,7 @@
   ],
   "license": "MIT",
   "files": [
-    "dist",
-    "index.d.ts"
+    "dist"
   ],
   "devDependencies": {
     "@babel/cli": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "repository": "github/query-selector",
   "main": "dist/index.umd.js",
   "module": "dist/index.esm.js",
+  "types": "index.d.ts",
   "scripts": {
     "clean": "rm -rf dist",
     "lint": "eslint index.js test/ && flow check",
@@ -21,7 +22,8 @@
   ],
   "license": "MIT",
   "files": [
-    "dist"
+    "dist",
+    "index.d.ts"
   ],
   "devDependencies": {
     "@babel/cli": "^7.0.0",

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,0 +1,26 @@
+import {query, querySelectorAll, closest, getAttribute, namedItem} from "../index";
+
+const bodyElement1 = query(document, 'body');
+const bodyElement2 = query(document, 'body', HTMLBodyElement);
+const bodyElement3 = query<HTMLBodyElement>(document, 'body');
+const bodyElement4 = query<HTMLBodyElement>(document, 'body', HTMLBodyElement);
+
+const formElements1 = querySelectorAll(bodyElement1, '.js-comment-form');
+const formElements2 = querySelectorAll(bodyElement2, '.js-comment-form', HTMLFormElement);
+const formElements3 = querySelectorAll<HTMLFormElement>(bodyElement3, '.js-comment-form');
+const formElements4 = querySelectorAll<HTMLFormElement>(bodyElement4, '.js-comment-form', HTMLFormElement);
+
+const htmlElement1 = closest(bodyElement1, 'html');
+const htmlElement2 = closest(bodyElement2, 'html', HTMLHtmlElement);
+const htmlElement3 = closest<HTMLHtmlElement>(bodyElement3, 'html');
+const htmlElement4 = closest<HTMLHtmlElement>(bodyElement4, 'html', HTMLHtmlElement);
+
+const bodyThing = getAttribute(bodyElement1, 'data-things');
+
+const commentForm = formElements3[0];
+
+const usernameField = namedItem(commentForm, 'username');
+const nameField = namedItem(commentForm, 'name', HTMLInputElement);
+const emailField = namedItem<HTMLFormElement>(commentForm, 'email', HTMLInputElement);
+const mailinglistsField = namedItem<HTMLFormElement>(commentForm, 'mailinglists', RadioNodeList);
+const locationField = namedItem<HTMLFormElement>(commentForm, 'location', HTMLSelectElement);


### PR DESCRIPTION
There's a `test.ts`, though no runner, to verify the typings work as expected. Do you want me to setup a task and run this through Typescript for verification? I'm using VS Code which does this for me, but it'd probably be nice to have as a task so CI can run it too.

The `lib.dom.d.ts` provided with Typescript has `HTMLElement` and friends not defined as classes for some reason. This prevents us from using `T` as a parameter constraint on `klass` right now which is why it's set to `any` 😕

The npm scripts don't work on Windows, but I was able to get it working in bash on WSL thanks to https://gist.github.com/micahgodbolt/8b9a338c8bab7bc147975646ea20826c. The test script fails, but the build one works and produces the correct `/dist` folder.

Closes #1 