### PR TITLE
Remove syntax transformations in module output

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,15 +43,7 @@
   "babel": {
     "env": {
       "esm": {
-        "presets": [
-          [
-            "@babel/env",
-            {
-              "modules": false
-            }
-          ],
-          "@babel/flow"
-        ]
+        "presets": ["@babel/flow"]
       },
       "umd": {
         "plugins": [


### PR DESCRIPTION
We're inadvertently transforming the `class` and `for…of` syntax in the module output file. Browsers that support modules also support this syntax, so just strip Flow types during compilation.